### PR TITLE
support libuv 0.10.21

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -28,10 +28,7 @@ func Ip4Addr(host string, port uint16) (SockaddrIn, error) {
 	phost := C.CString(host)
 	defer C.free(unsafe.Pointer(phost))
 	var addr C.struct_sockaddr_in
-	r := C.uv_ip4_addr(phost, C.int(port), &addr)
-	if r != 0 {
-		return nil, errors.New(C.GoString(C.uv_strerror(r)))
-	}
+	addr = C.uv_ip4_addr(phost, C.int(port))
 	return &SockaddrIn4 {addr}, nil
 }
 
@@ -39,10 +36,7 @@ func Ip6Addr(host string, port uint16) (SockaddrIn, error) {
 	phost := C.CString(host)
 	defer C.free(unsafe.Pointer(phost))
 	var addr C.struct_sockaddr_in6
-	r := C.uv_ip6_addr(phost, C.int(port), &addr)
-	if r != 0 {
-		return nil, errors.New(C.GoString(C.uv_strerror(r)))
-	}
+	addr = C.uv_ip6_addr(phost, C.int(port))
 	return &SockaddrIn6 {addr}, nil
 }
 
@@ -50,7 +44,9 @@ func (sa *SockaddrIn4) Name() (name string, err error) {
 	b := make([]byte, 256)
 	r := C.uv_ip4_name(&sa.sa, (*C.char)(unsafe.Pointer(&b[0])), C.size_t(len(b)));
 	if r != 0 {
-		return "", errors.New(C.GoString(C.uv_strerror(r)))
+		var error C.uv_err_t
+		error.code = C.uv_err_code(r)
+		return "", errors.New(C.GoString(C.uv_strerror(error)))
 	}
 	return string(b), nil
 }
@@ -59,7 +55,9 @@ func (sa *SockaddrIn6) Name() (name string, err error) {
 	b := make([]byte, 256)
 	r := C.uv_ip6_name(&sa.sa, (*C.char)(unsafe.Pointer(&b[0])), C.size_t(len(b)));
 	if r != 0 {
-		return "", errors.New(C.GoString(C.uv_strerror(r)))
+		var error C.uv_err_t
+		error.code = C.uv_err_code(r)
+		return "", errors.New(C.GoString(C.uv_strerror(error)))
 	}
 	return string(b), nil
 }

--- a/error.go
+++ b/error.go
@@ -10,7 +10,9 @@ type Error struct {
 }
 
 func (err *Error) String() string {
-	return C.GoString(C.uv_strerror(C.int(err.e)))
+	var error C.uv_err_t
+	error.code = C.uv_err_code(err.e)
+	return C.GoString(C.uv_strerror(error))
 }
 
 func (err *Error) Error() string {
@@ -18,5 +20,7 @@ func (err *Error) Error() string {
 }
 
 func (err *Error) Name() string {
-	return C.GoString(C.uv_err_name(C.int(err.e)))
+	var error C.uv_err_t
+	error.code = C.uv_err_code(err.e)
+	return C.GoString(C.uv_err_name(error))
 }

--- a/process.go
+++ b/process.go
@@ -8,7 +8,7 @@ import "C"
 import "unsafe"
 
 type ProcessOptions struct {
-  Exit_cb func(*Handle, int64, int)
+  Exit_cb func(*Handle, int, int)
   File string
   Args []string
   Env []string

--- a/tcp.go
+++ b/tcp.go
@@ -34,15 +34,10 @@ func (tcp *Tcp) Bind(sa SockaddrIn) (err error) {
 	var r int
 	sa4, is_v4 := sa.(*SockaddrIn4)
 	if is_v4 {
-		r = uv_tcp_bind(tcp.t, &sa4.sa, 0)
+		r = uv_tcp_bind(tcp.t, sa4.sa)
 	} else {
-		r = uv_tcp_bind(tcp.t, &sa4.sa, 1)
-		/*
-		sa6, is_v6 := sa.(*SockaddrIn6)
-		if is_v6 {
-			r = uv_tcp_bind(tcp.t, &sa6.sa, 1)
-		}
-		*/
+		sa6, _ := sa.(*SockaddrIn6)
+		r = uv_tcp_bind6(tcp.t, sa6.sa)
 	}
 	if r != 0 {
 		return &Error{r}
@@ -84,11 +79,11 @@ func (tcp *Tcp) Connect(sa SockaddrIn, cb func(*Request, int)) (err error) {
 	var r int
 	sa4, is_v4 := sa.(*SockaddrIn4)
 	if is_v4 {
-		r = uv_tcp_connect(tcp.t, &sa4.sa)
+		r = uv_tcp_connect(tcp.t, sa4.sa)
 	} else {
 		sa6, is_v6 := sa.(*SockaddrIn6)
 		if is_v6 {
-			r = uv_tcp_connect6(tcp.t, &sa6.sa)
+			r = uv_tcp_connect6(tcp.t, sa6.sa)
 		}
 	}
 	if r != 0 {

--- a/udp.go
+++ b/udp.go
@@ -34,11 +34,11 @@ func (udp *Udp) Bind(sa SockaddrIn, flags uint) (err error) {
 	var r int
 	sa4, is_v4 := sa.(*SockaddrIn4)
 	if is_v4 {
-		r = uv_udp_bind(udp.u, &sa4.sa, flags)
+		r = uv_udp_bind(udp.u, sa4.sa, flags)
 	} else {
 		sa6, is_v6 := sa.(*SockaddrIn6)
 		if is_v6 {
-			r = uv_udp_bind6(udp.u, &sa6.sa, flags)
+			r = uv_udp_bind6(udp.u, sa6.sa, flags)
 		}
 	}
 	if r != 0 {
@@ -72,11 +72,11 @@ func (udp *Udp) Send(b []byte, sa SockaddrIn, cb func(*Request, int)) (err error
 	var r int
 	sa4, is_v4 := sa.(*SockaddrIn4)
 	if is_v4 {
-		r = uv_udp_send(udp.u, &buf, 1, &sa4.sa)
+		r = uv_udp_send(udp.u, &buf, 1, sa4.sa)
 	} else {
 		sa6, is_v6 := sa.(*SockaddrIn6)
 		if is_v6 {
-			r = uv_udp_send6(udp.u, &buf, 1, &sa6.sa)
+			r = uv_udp_send6(udp.u, &buf, 1, sa6.sa)
 		}
 	}
 	if r != 0 {


### PR DESCRIPTION
libuvの0.10系で動作しないようなので修正しました。主にコンパイルエラーを潰していっただけなので
修正内容的に変なのがあるかもしれませんがとりあえず動いていそうです。

```
macbook% go version
go version go1.2.1 darwin/amd64
```
### 変わった点などの簡単なメモ
#### uv_ip4_addr

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L1794
パラメーターでstruct sockaddr_inを受けるのではなく返り値で返すようになりました
#### uv_ip6_addr

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L1795
パラメーターでstruct sockaddr_inを受けるのではなく返り値で返すようになりました
#### uv_strerror

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L425
uv_err_tに変わりました
#### uv_read_cb

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L357
uv_buf_tがポインタからそのままへ
#### uv_udp_recv_cb

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L768
uv_buf_tがポインタから構造体のままにかわりました
#### uv_exit_cb

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L379
型がちがってたっぽいので修正
#### uv_alloc_cb

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L343
パラメーターでuv_buf_tを渡すのではなく作って返すようになりました
#### uv_udp_send

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L752
ポインタから構造体のままにかわりました
#### uv_udp_send6

https://github.com/joyent/libuv/blob/v0.10.21/include/uv.h#L931
ポインタから構造体のままにかわりました
